### PR TITLE
Assign management link to category TOOLS

### DIFF
--- a/src/main/java/org/jenkins/ci/plugins/saferestart/SafeRestartManagementLink.java
+++ b/src/main/java/org/jenkins/ci/plugins/saferestart/SafeRestartManagementLink.java
@@ -64,4 +64,8 @@ public class SafeRestartManagementLink extends ManagementLink {
   public String getUrlName() {
     return getUrlName(Stapler.getCurrentRequest());
   }
+  
+  public String getCategoryName() {
+    return "TOOLS";
+  }
 }


### PR DESCRIPTION
Move the "Restart safely" link from "Uncategorized" to "Tools and Actions" in the Jenkins management page.