### PR TITLE
chore(github): Adds CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkinsci/saferestart-plugin-developers


### PR DESCRIPTION
This PR adds a CODEOWNERS file to automatically add @jenkinsci/saferestart-plugin-developers team as a reviewer on pull requests.