### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.6</version>
     <relativePath />
   </parent>
 
@@ -57,8 +57,8 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>

--- a/src/main/java/org/jenkins/ci/plugins/saferestart/SafeRestartManagementLink.java
+++ b/src/main/java/org/jenkins/ci/plugins/saferestart/SafeRestartManagementLink.java
@@ -29,7 +29,7 @@ import hudson.Extension;
 import hudson.model.ManagementLink;
 import hudson.model.ManagementLink.Category;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * ManagementLink for SafeRestart. Added restart link to system administrator.
@@ -39,7 +39,7 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 @Extension
 public class SafeRestartManagementLink extends ManagementLink {
-    protected static String getUrlName(final StaplerRequest request) {
+    protected static String getUrlName(final StaplerRequest2 request) {
         if (request == null) {
             return Constants.RESTART_URL;
         }
@@ -64,7 +64,7 @@ public class SafeRestartManagementLink extends ManagementLink {
 
     @Override
     public String getUrlName() {
-        return getUrlName(Stapler.getCurrentRequest());
+        return getUrlName(Stapler.getCurrentRequest2());
     }
 
     @Override

--- a/src/test/java/org/jenkins/ci/plugins/saferestart/SafeRestartManagementLinkTest.java
+++ b/src/test/java/org/jenkins/ci/plugins/saferestart/SafeRestartManagementLinkTest.java
@@ -42,7 +42,7 @@ public class SafeRestartManagementLinkTest {
     }
 
     @Test
-    public void testGetUrlName_StaplerRequest() {
+    public void testGetUrlName_StaplerRequest2() {
         assertThat(SafeRestartManagementLink.getUrlName(null), is(Constants.RESTART_URL));
     }
 


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Require Jenkins 2.479.1 and Jakarta EE 9 so that we can eventually remove more of the compatibility layer that provides compatibility with plugins built for Java EE 8 and other earlier technologies.

### Testing done

Automated tests pass locally.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
